### PR TITLE
[FF-A][TPM] TPM Service Updates for Open/Close Locality + More

### DIFF
--- a/FfaFeaturePkg/Applications/FfaPartitionTest/FfaPartitionTestApp.c
+++ b/FfaFeaturePkg/Applications/FfaPartitionTest/FfaPartitionTestApp.c
@@ -312,6 +312,60 @@ FfaPartitionTestAppEntry (
     DEBUG ((DEBUG_INFO, "TPM Service Interface Version: %d.%d\n", DirectMsgArgsEx.Arg1 >> 16, DirectMsgArgsEx.Arg1 & 0xFFFF));
   }
 
+  // Call the TPM Service to close locality0
+  ZeroMem (&DirectMsgArgsEx, sizeof (DirectMsgArgsEx));
+  DirectMsgArgsEx.Arg0 = 0x0F000201;
+  DirectMsgArgsEx.Arg1 = 0x101; // Close Locality
+  DirectMsgArgsEx.Arg2 = 0x00;  // Locality Qualifier
+  Status               = FfaMessageSendDirectReq2 (FfaTestPartInfo.PartitionId, &FfaTpmServiceGuid, &DirectMsgArgsEx);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "Unable to communicate direct req 2 with FF-A Ffa test SP (%r).\n", Status));
+    goto Done;
+  }
+
+  if (DirectMsgArgsEx.Arg0 != 0x05000001) {
+    DEBUG ((DEBUG_ERROR, "Command Failed: %x\n", DirectMsgArgsEx.Arg0));
+    goto Done;
+  } else {
+    DEBUG ((DEBUG_INFO, "TPM Service Close Locality Success\n"));
+  }
+
+  // Call the TPM Service to request locality0
+  ZeroMem (&DirectMsgArgsEx, sizeof (DirectMsgArgsEx));
+  DirectMsgArgsEx.Arg0 = 0x0F000201;
+  DirectMsgArgsEx.Arg1 = 0x01; // Request Locality
+  DirectMsgArgsEx.Arg2 = 0x00; // Locality Qualifier
+  Status               = FfaMessageSendDirectReq2 (FfaTestPartInfo.PartitionId, &FfaTpmServiceGuid, &DirectMsgArgsEx);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "Unable to communicate direct req 2 with FF-A Ffa test SP (%r).\n", Status));
+    goto Done;
+  }
+
+  if (DirectMsgArgsEx.Arg0 != 0x8E00000A) {
+    DEBUG ((DEBUG_ERROR, "Command Failed: %x\n", DirectMsgArgsEx.Arg0));
+    goto Done;
+  } else {
+    DEBUG ((DEBUG_INFO, "TPM Service Rejected Request, Locality Closed\n"));
+  }
+
+  // Call the TPM Service to reopen locality0
+  ZeroMem (&DirectMsgArgsEx, sizeof (DirectMsgArgsEx));
+  DirectMsgArgsEx.Arg0 = 0x0F000201;
+  DirectMsgArgsEx.Arg1 = 0x100; // Open Locality
+  DirectMsgArgsEx.Arg2 = 0x00;  // Locality Qualifier
+  Status               = FfaMessageSendDirectReq2 (FfaTestPartInfo.PartitionId, &FfaTpmServiceGuid, &DirectMsgArgsEx);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "Unable to communicate direct req 2 with FF-A Ffa test SP (%r).\n", Status));
+    goto Done;
+  }
+
+  if (DirectMsgArgsEx.Arg0 != 0x05000001) {
+    DEBUG ((DEBUG_ERROR, "Command Failed: %x\n", DirectMsgArgsEx.Arg0));
+    goto Done;
+  } else {
+    DEBUG ((DEBUG_INFO, "TPM Service Open Locality Success\n"));
+  }
+
  #endif
 
   // Invoke the Test Service to trigger a notification event

--- a/FfaFeaturePkg/Library/TpmServiceLib/TpmServiceLib.c
+++ b/FfaFeaturePkg/Library/TpmServiceLib/TpmServiceLib.c
@@ -18,6 +18,8 @@
 **/
 
 #include <Uefi.h>
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
 #include <Library/DebugLib.h>
 #include <Library/BaseMemoryLib.h>
 #include <Library/TpmServiceLib.h>
@@ -27,11 +29,13 @@
 #include <IndustryStandard/Tpm20.h>
 
 /* TPM Service Defines */
-#define TPM_MAJOR_VER  (1)
-#define TPM_MINOR_VER  (0)
+#define TPM_MAJOR_VER  (0x1)
+#define TPM_MINOR_VER  (0x0)
 
-#define TPM_START_PROCESS_CMD      (0)
-#define TPM_START_PROCESS_LOC_REQ  (1)
+#define TPM_START_PROCESS_CMD        (0x0)
+#define TPM_START_PROCESS_LOC_REQ    (0x1)
+#define TPM_START_PROCESS_OPEN_LOC   (0x100)
+#define TPM_START_PROCESS_CLOSE_LOC  (0x101)
 
 #define TPM_LOCALITY_OFFSET  (0x1000)
 
@@ -117,6 +121,13 @@ InitInternalCrb (
   SetMem ((void *)InternalTpmCrb, sizeof (PTP_CRB_REGISTERS), 0x00);
   InternalTpmCrb->InterfaceId      = mInterfaceIdDefault.Uint32;
   InternalTpmCrb->CrbControlStatus = PTP_CRB_CONTROL_AREA_STATUS_TPM_IDLE;
+
+  /* Set the CRB Command/Response buffer address + size. */
+  InternalTpmCrb->CrbControlCommandAddressHigh = (UINT32)RShiftU64 ((UINTN)InternalTpmCrb->CrbDataBuffer, 32);
+  InternalTpmCrb->CrbControlCommandAddressLow  = (UINT32)(UINTN)InternalTpmCrb->CrbDataBuffer;
+  InternalTpmCrb->CrbControlCommandSize        = sizeof(InternalTpmCrb->CrbDataBuffer);
+  InternalTpmCrb->CrbControlResponseAddrss     = (UINTN)InternalTpmCrb->CrbDataBuffer;
+  InternalTpmCrb->CrbControlResponseSize       = sizeof(InternalTpmCrb->CrbDataBuffer);
 }
 
 /**
@@ -184,6 +195,13 @@ CleanInternalCrb (
   } else {
     InternalTpmCrb->CrbControlStatus = 0;
   }
+
+  /* Set the CRB Command/Response buffer address + size. */
+  InternalTpmCrb->CrbControlCommandAddressHigh = (UINT32)RShiftU64 ((UINTN)InternalTpmCrb->CrbDataBuffer, 32);
+  InternalTpmCrb->CrbControlCommandAddressLow  = (UINT32)(UINTN)InternalTpmCrb->CrbDataBuffer;
+  InternalTpmCrb->CrbControlCommandSize        = sizeof(InternalTpmCrb->CrbDataBuffer);
+  InternalTpmCrb->CrbControlResponseAddrss     = (UINTN)InternalTpmCrb->CrbDataBuffer;
+  InternalTpmCrb->CrbControlResponseSize       = sizeof(InternalTpmCrb->CrbDataBuffer);
 
   /* Remaining registers can be ignored. */
 }
@@ -342,12 +360,6 @@ HandleLocalityRequest (
 
   InternalTpmCrb = (PTP_CRB_REGISTERS_PTR)(UINTN)(PcdGet64 (PcdTpmInternalBaseAddress) + (Locality * TPM_LOCALITY_OFFSET));
 
-  /* Check if the locality is open */
-  if (mLocalityStates[Locality] == TPM_LOCALITY_CLOSED) {
-    DEBUG ((DEBUG_ERROR, "Locality Closed\n"));
-    return TPM2_FFA_ERROR_DENIED;
-  }
-
   /* Check if we are doing a locality relinquish */
   if (InternalTpmCrb->LocalityControl & PTP_CRB_LOCALITY_CONTROL_RELINQUISH) {
     /* Make sure the locality being relinquished is the active locality */
@@ -449,24 +461,43 @@ StartHandler (
   )
 {
   TpmStatus  ReturnVal;
-  UINT8      Function;
+  UINT16     Function;
   UINT8      Locality;
 
   ReturnVal = TPM2_FFA_SUCCESS_OK;
   Function  = Request->Arg1;
   Locality  = Request->Arg2;
 
-  /* Based on the function we will need to read from the corresponding address
-    * register in the tpm_crb to know where to pull the data from:
-    * NOTE: function = 0, command is ready to be processed
-    *       function = 1, locality request is ready to be processed
-    *       locality = 0...4, the locality where the command or request is located */
+  /* Check to make sure we received a valid locality */
   if (Locality >= NUM_LOCALITIES) {
     Response->Arg0 = TPM2_FFA_ERROR_INVARG;
     DEBUG ((DEBUG_ERROR, "Invalid Locality\n"));
-    return TPM2_FFA_ERROR_INVARG;
+    ReturnVal = TPM2_FFA_ERROR_INVARG;
+    goto exit;
   }
 
+  /* NOTE: The following commands should only be coming
+   *       from TF-A. */
+  /* Check if there was a request to open a locality */
+  if (Function == TPM_START_PROCESS_OPEN_LOC) {
+    /* Set the locality state to OPEN */
+    mLocalityStates[Locality] = TPM_LOCALITY_OPEN;
+    goto exit;
+  /* Check if there was a request to close a locality */
+  } else if (Function == TPM_START_PROCESS_CLOSE_LOC) {
+    /* Set the locality state to CLOSED */
+    mLocalityStates[Locality] = TPM_LOCALITY_CLOSED;
+    goto exit;
+  }
+
+  /* Check if the locality is open */
+  if (mLocalityStates[Locality] == TPM_LOCALITY_CLOSED) {
+    DEBUG ((DEBUG_ERROR, "Locality Closed\n"));
+    ReturnVal = TPM2_FFA_ERROR_DENIED;
+    goto exit;
+  }
+
+  /* Check if we are processing a command */
   if (Function == TPM_START_PROCESS_CMD) {
     /* We should only proceed if the locality being requested matches that of the
      * current locality that is active. */
@@ -476,13 +507,16 @@ StartHandler (
       ReturnVal = TPM2_FFA_ERROR_INVARG;
       DEBUG ((DEBUG_ERROR, "Locality Mismatch\n"));
     }
+  /* Check if we are processing a locality request */
   } else if (Function == TPM_START_PROCESS_LOC_REQ) {
     ReturnVal = HandleLocalityRequest (Locality);
+  /* Otherwise, invalid function ID */
   } else {
     ReturnVal = TPM2_FFA_ERROR_INVARG;
     DEBUG ((DEBUG_ERROR, "Invalid Start Function\n"));
   }
 
+exit:
   /* Clean up the internal CRB at the given locality */
   CleanInternalCrb ();
 
@@ -585,9 +619,14 @@ TpmServiceInit (
     InitInternalCrb (Locality);
   }
 
-  /* TODO: Request Locality states from TFA */
+  /* Default the locality states */
   for (Locality = 0; Locality < NUM_LOCALITIES; Locality++) {
-    mLocalityStates[Locality] = TPM_LOCALITY_OPEN;
+    /* Locality 0 and 1 are open by default */
+    if ((Locality == 0)|| (Locality == 1)) {
+      mLocalityStates[Locality] = TPM_LOCALITY_OPEN;
+    } else {
+      mLocalityStates[Locality] = TPM_LOCALITY_CLOSED;
+    }
   }
 
   /* Initialize the TPM Service State Translation Library. */

--- a/FfaFeaturePkg/Library/TpmServiceLib/TpmServiceLib.inf
+++ b/FfaFeaturePkg/Library/TpmServiceLib/TpmServiceLib.inf
@@ -26,6 +26,8 @@
   FfaFeaturePkg/FfaFeaturePkg.dec
 
 [LibraryClasses]
+  BaseLib
+  BaseMemoryLib
   DebugLib
   PlatformFfaInterruptLib
   ArmSvcLib


### PR DESCRIPTION
# Preface

Please ensure you have read the [contribution docs](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md) prior
to submitting the pull request. In particular,
[pull request guidelines](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md#pull-request-best-practices).

## Description

Updated the TPM service to include support for Open/Close locality states. TPM service now properly defaults the internal CRB command/response address and size registers. Cleaned up the translation library to no longer set the external CRB command/response address and size registers. Removed the response header code as it is not necessary, we can copy the entire CRB region for both command and response. Added tests to the FfaPartitionTestApp to test open/close locality. Fixed a bug where the error code wouldn't be returned if an invalid locality was passed in.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Verified changes using the FfaPartitionTestApp with TPM enabled in QEMU SBSA.

## Integration Instructions

N/A
