### PR TITLE
Updated FF-A notification definitions

### DIFF
--- a/FfaFeaturePkg/Applications/FfaPartitionTest/FfaPartitionTestApp.c
+++ b/FfaFeaturePkg/Applications/FfaPartitionTest/FfaPartitionTestApp.c
@@ -85,7 +85,7 @@ ApIrqInterruptHandler (
   DEBUG ((DEBUG_INFO, "Received IRQ interrupt %d!\n", Source));
 
   // Then register this test app to receive notifications from the Ffa test SP
-  Status = FfaNotificationGet (0, FFA_NOTIFICATIONS_FLAG_BITMAP_SP, &Bitmap);
+  Status = FfaNotificationGet (0, ARM_FFA_NOTIFICATION_FLAG_BITMAP_SP, &Bitmap);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "Unable to notification get with FF-A Ffa test SP (%r).\n", Status));
   } else {

--- a/FfaFeaturePkg/Library/ArmFfaLibEx/ArmFfaLibEx.c
+++ b/FfaFeaturePkg/Library/ArmFfaLibEx/ArmFfaLibEx.c
@@ -426,13 +426,13 @@ FfaNotificationGet (
   }
 
   switch (Flags) {
-    case FFA_NOTIFICATIONS_FLAG_BITMAP_SP:
+    case ARM_FFA_NOTIFICATION_FLAG_BITMAP_SP:
       *NotificationBitmap = ((UINT64)Result.Arg3 << 32) | Result.Arg2;
       break;
-    case FFA_NOTIFICATIONS_FLAG_BITMAP_VM:
+    case ARM_FFA_NOTIFICATION_FLAG_BITMAP_VM:
       *NotificationBitmap = ((UINT64)Result.Arg5 << 32) | Result.Arg4;
       break;
-    case FFA_NOTIFICATIONS_FLAG_BITMAP_HYP:
+    case ARM_FFA_NOTIFICATION_FLAG_BITMAP_HYP:
       *NotificationBitmap = ((UINT64)Result.Arg7 << 32) | Result.Arg6;
       break;
     default:


### PR DESCRIPTION
## Description

This change updated the consumed macro definitions to match the macro names from ArmPkg.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [x] Impacts functionality?
- [ ] Impacts security?
- [x] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

This is tested on QEMU SBSA and booted to UEFI shell.

## Integration Instructions

Must be integrated with the latest ArmPkg including this change: https://github.com/microsoft/mu_silicon_arm_tiano/pull/392
