### PR TITLE
FfaPartitionTestApp: Remove unused variable [Rebase & FF]

### DIFF
--- a/FfaFeaturePkg/Applications/FfaPartitionTest/FfaPartitionTestApp.c
+++ b/FfaFeaturePkg/Applications/FfaPartitionTest/FfaPartitionTestApp.c
@@ -460,7 +460,6 @@ FfaMiscRegisterNotifications (
   )
 {
   EFI_STATUS  Status = EFI_SUCCESS;
-  UINT64      Bitmap;
   UINTN       SriIndex;
   UINTN       Dummy;
 
@@ -484,8 +483,6 @@ FfaMiscRegisterNotifications (
       UT_ASSERT_NOT_EFI_ERROR (Status);
     }
   }
-
-  DEBUG ((DEBUG_INFO, "Registered notification with FF-A Ffa test SP with VM bitmap %x.\n", Bitmap));
 
   return UNIT_TEST_PASSED;
 }

--- a/FfaFeaturePkg/Library/TpmServiceStateTranslationLib/TpmServiceStateTranslationLib.c
+++ b/FfaFeaturePkg/Library/TpmServiceStateTranslationLib/TpmServiceStateTranslationLib.c
@@ -19,7 +19,6 @@
 #include <Library/TimerLib.h>
 #include <Library/DebugLib.h>
 #include <Library/TpmServiceStateTranslationLib.h>
-#include <Library/Tpm2DebugLib.h>
 #include <IndustryStandard/Tpm20.h>
 
 /* TPM Service State Translation Library Defines */
@@ -37,6 +36,76 @@ STATIC BOOLEAN  mIsCrbInterface;
 STATIC BOOLEAN  mIsIdleBypassSupported;
 
 /* TPM Service State Translation Library Static Functions */
+
+/**
+  This function dumps as much information as possible about
+  a command being sent to the TPM for maximum user-readability.
+
+  @param[in]  InputBlockSize  Size of the input buffer.
+  @param[in]  InputBlock      Pointer to the input buffer itself.
+
+**/
+VOID
+EFIAPI
+DumpTpmInputBlock (
+  IN UINT32       InputBlockSize,
+  IN CONST UINT8  *InputBlock
+  )
+{
+  UINTN  Index, DebugSize;
+
+  DEBUG ((DEBUG_INFO, "TpmCommand Send - "));
+
+  if (InputBlockSize > 0x100) {
+    DebugSize = 0x40;
+  } else {
+    DebugSize = InputBlockSize;
+  }
+
+  for (Index = 0; Index < DebugSize; Index++) {
+    DEBUG ((DEBUG_INFO, "%02x ", InputBlock[Index]));
+  }
+
+  if (DebugSize != InputBlockSize) {
+    DEBUG ((DEBUG_INFO, "...... "));
+
+    for (Index = InputBlockSize - 0x20; Index < InputBlockSize; Index++) {
+      DEBUG ((DEBUG_INFO, "%02x ", InputBlock[Index]));
+    }
+  }
+
+  DEBUG ((DEBUG_INFO, "\n"));
+
+  return;
+} // DumpTpmInputBlock()
+
+/**
+  This function dumps as much information as possible about
+  a response from the TPM for maximum user-readability.
+
+  @param[in]  OutputBlockSize  Size of the output buffer.
+  @param[in]  OutputBlock      Pointer to the output buffer itself.
+
+**/
+VOID
+EFIAPI
+DumpTpmOutputBlock (
+  IN UINT32       OutputBlockSize,
+  IN CONST UINT8  *OutputBlock
+  )
+{
+  UINTN  Index;
+
+  DEBUG ((DEBUG_INFO, "TpmCommand Receive - "));
+
+  for (Index = 0; Index < OutputBlockSize; Index++) {
+    DEBUG ((DEBUG_INFO, "%02x ", OutputBlock[Index]));
+  }
+
+  DEBUG ((DEBUG_INFO, "\n"));
+
+  return;
+} // DumpTpmOutputBlock()
 
 /**
   Returns the BurstCount from the ExternalFifo

--- a/FfaFeaturePkg/Library/TpmServiceStateTranslationLib/TpmServiceStateTranslationLib.inf
+++ b/FfaFeaturePkg/Library/TpmServiceStateTranslationLib/TpmServiceStateTranslationLib.inf
@@ -31,7 +31,6 @@
   IoLib
   TimerLib
   DebugLib
-  Tpm2DebugLib
 
 [Pcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdFfaLibConduitSmc       ## CONSUMES


### PR DESCRIPTION
## Description

Remove unused `Bitmap` variable in FfaMiscRegisterNotifications() which causes a build failure with CLANGPDB.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Compile FfaPartitionTestApp with CLANGPDB

## Integration Instructions

- N/A