### PR TITLE
LICENSE.txt: Delete file (keep License.txt)

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,0 @@
-BSD-2-Clause-Patent License
-
-Copyright (C) Microsoft Corporation. All rights reserved.
-SPDX-License-Identifier: BSD-2-Clause-Patent


### PR DESCRIPTION
## Description

Right now, duplicate copies of the file exist with different case as the file was originally named `LICENSE.txt` in the repo but is being synced as `License.txt`.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

N/A

## Integration Instructions

N/A