### PR TITLE
FfaFeaturePkg/SecurePartitionEntryPoint: Add gHobList

### DIFF
--- a/FfaFeaturePkg/Library/SecurePartitionEntryPoint/StandaloneMmCoreEntryPoint.c
+++ b/FfaFeaturePkg/Library/SecurePartitionEntryPoint/StandaloneMmCoreEntryPoint.c
@@ -36,6 +36,12 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #define FFA_PAGE_16K  1
 #define FFA_PAGE_64K  2
 
+//
+// This symbol is needed for this module to link against the Standalone MM Core instance of HobLib
+// (StandaloneMmPkg/Library/StandaloneMmCoreHobLib/StandaloneMmCoreHobLib.inf)
+//
+VOID  *gHobList = NULL;
+
 // Materialize the Secure Partition Services Table
 SECURE_PARTITION_SERVICES_TABLE  mSpst = {
   .FDTAddress = NULL


### PR DESCRIPTION
## Description

The MsSecurePartition.inf module is of type `MM_CORE_STANDALONE`.

Although it does not directly depend on `HobLib`, libraries attached
to it could. The `MM_CORE_STANDALONE` instance of `HobLib` in
StandaloneMmPkg depends on the symbol `gHobList` to be defined in
the core. Add this symbol to `SecurePartitionEntryPoint` which is
equivalent to where the symbol is defined for the Arm Standalone
MM Core:

  `ArmPkg/Library/ArmStandaloneMmCoreEntryPoint`

This change adds that symbol so HOB the library instance can
successfully be linked.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- FfaFeaturePkg build
- Integration of MsSecurePartition into a platform

## Integration Instructions

- The platform should ensure a `MM_CORE_STANDALONE` instance of `HobLib` is defined in the platform DSC.