### PR TITLE
Build rust secure partitions when releases are made

### DIFF
--- a/.github/workflows/release-secure-partitions.yml
+++ b/.github/workflows/release-secure-partitions.yml
@@ -24,10 +24,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-22.04
-            tool_chain: GCC5
-            output_dir: "BaseTools/Source/C/bin"
-            target: AARCH64
+          - os: ubuntu-24.04
+            output_dir: "output"
+            target: "aarch64-unknown-none"
 
     runs-on: ${{ matrix.os }}
 
@@ -49,27 +48,18 @@ jobs:
 
       - name: Build Secure Partitions
         run: |
-          cargo build --target=aarch64-unknown-none
-          cargo objcopy --target=aarch64-unknown-none -- -O binary msft-sp.bin
-
-      - name: Upload Build Logs
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: logs-${{ matrix.tool_chain }}-${{ matrix.target }}
-          path: |
-            Build/SETUPLOG.txt
-            Build/UPDATE_LOG.txt
-            BaseTools/BaseToolsBuild/BASETOOLS_BUILD.txt
+          cargo build --target=${{ matrix.target }}
+          cargo objcopy --target=${{ matrix.target }} -- -O binary ${{ matrix.output_dir }}/msft-sp.bin
+          copy ${{ matrix.target }}/debug/msft-sp ${{ matrix.output_dir }}/msft-sp.elf
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: basetools-${{ matrix.tool_chain }}-${{ matrix.target }}
+          name: rust-secure-partitions
           path: ${{ matrix.output_dir }}
 
   publish:
-    name: Publish Base Tools
+    name: Publish Rust Partitions
     needs: build
     if: github.event_name == 'release'
     runs-on: ubuntu-latest
@@ -86,24 +76,15 @@ jobs:
         with:
           path: ${{ runner.temp }}/artifacts
 
-      - name: Stage Files
-        run: mkdir ${{ runner.temp }}/basetools ;
-          mv ${{ runner.temp }}/artifacts/basetools-GCC5-X64       ${{ runner.temp }}/basetools/Linux-x86 ;
-          chmod a+x ${{ runner.temp }}/basetools/Linux-x86/* ;
-          mv ${{ runner.temp }}/artifacts/basetools-GCC5-AARCH64   ${{ runner.temp }}/basetools/Linux-ARM-64 ;
-          chmod a+x ${{ runner.temp }}/basetools/Linux-ARM-64/* ;
-          mv ${{ runner.temp }}/artifacts/basetools-VS2022-IA32    ${{ runner.temp }}/basetools/Windows-x86 ;
-          mv ${{ runner.temp }}/artifacts/basetools-VS2022-AARCH64 ${{ runner.temp }}/basetools/Windows-ARM-64 ;
-
       - name: Package Files
         run: |
           cd ${{ runner.temp }} ;
-          zip -r basetools-${{ github.event.release.tag_name }}.zip basetools/* ;
-          tar -czf basetools-${{ github.event.release.tag_name }}.tar.gz basetools/*
+          zip -r rust-secure-partitions-${{ github.event.release.tag_name }}.zip rust-secure-partitions/* ;
+          tar -czf rust-secure-partitions-${{ github.event.release.tag_name }}.tar.gz rust-secure-partitions/*
 
       - name: Upload Release Asset
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release upload ${{ github.event.release.tag_name }} ${{ runner.temp }}/basetools-*.zip
-          gh release upload ${{ github.event.release.tag_name }} ${{ runner.temp }}/basetools-*.tar.gz
+          gh release upload ${{ github.event.release.tag_name }} ${{ runner.temp }}/rust-secure-partitions-*.zip
+          gh release upload ${{ github.event.release.tag_name }} ${{ runner.temp }}/rust-secure-partitions-*.tar.gz

--- a/.github/workflows/release-secure-partitions.yml
+++ b/.github/workflows/release-secure-partitions.yml
@@ -21,42 +21,32 @@ on:
 jobs:
   build:
     name: Build Rust Secure Partition
-    strategy:
-      matrix:
-        include:
-          - os: ubuntu-24.04
-            output_dir: "output"
-            target: "aarch64-unknown-none"
+    env:
+      OUTOUTPUT_DIR: output
+      BUILD_TARGET: aarch64-unknown-none
 
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
 
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-
-      - name: Install Linux Tools
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu gcc-arm-linux-gnueabi g++-aarch64-linux-gnu g++-arm-linux-gnueabi
-          echo "GCC5_AARCH64_PREFIX=/usr/bin/aarch64-linux-gnu-" >> "$GITHUB_ENV"
-          echo "GCC5_ARM_PREFIX=/usr/bin/arm-linux-gnueabi-" >> "$GITHUB_ENV"
-
       - name: Build Secure Partitions
         run: |
-          cargo build --target=${{ matrix.target }}
-          cargo objcopy --target=${{ matrix.target }} -- -O binary ${{ matrix.output_dir }}/msft-sp.bin
-          copy ${{ matrix.target }}/debug/msft-sp ${{ matrix.output_dir }}/msft-sp.elf
+          cargo build --target=$BUILD_TARGET
+          env:
+            cargo objcopy --target=$BUILD_TARGET -- -O binary $OUTOUTPUT_DIR: /msft-sp.bi
+          env:
+            copy $BUILD_TARGET/debug/msft-sp $OUTOUTPUT_DIR: /msft-sp.el
+          env:
+            copy Cargo.lock $OUTOUTPUT_DIR: /Cargo.loc
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         with:
           name: rust-secure-partitions
-          path: ${{ matrix.output_dir }}
+          env:
+            path: $OUTOUTPUT_DIR
 
   publish:
     name: Publish Rust Partitions

--- a/.github/workflows/release-secure-partitions.yml
+++ b/.github/workflows/release-secure-partitions.yml
@@ -1,0 +1,109 @@
+# This workflow automatically publishes the rust secure partition binaries for a
+#  given release.
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+
+name: Rust Secure Partition Build
+
+on:
+  release:
+    types:
+      - published
+  pull_request:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/release-secure-partitions.yml"
+      - "FfaFeaturePkg/**"
+
+jobs:
+  build:
+    name: Build Rust Secure Partition
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-22.04
+            tool_chain: GCC5
+            output_dir: "BaseTools/Source/C/bin"
+            target: AARCH64
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install Linux Tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu gcc-arm-linux-gnueabi g++-aarch64-linux-gnu g++-arm-linux-gnueabi
+          echo "GCC5_AARCH64_PREFIX=/usr/bin/aarch64-linux-gnu-" >> "$GITHUB_ENV"
+          echo "GCC5_ARM_PREFIX=/usr/bin/arm-linux-gnueabi-" >> "$GITHUB_ENV"
+
+      - name: Build Secure Partitions
+        run: |
+          cargo build --target=aarch64-unknown-none
+          cargo objcopy --target=aarch64-unknown-none -- -O binary msft-sp.bin
+
+      - name: Upload Build Logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: logs-${{ matrix.tool_chain }}-${{ matrix.target }}
+          path: |
+            Build/SETUPLOG.txt
+            Build/UPDATE_LOG.txt
+            BaseTools/BaseToolsBuild/BASETOOLS_BUILD.txt
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: basetools-${{ matrix.tool_chain }}-${{ matrix.target }}
+          path: ${{ matrix.output_dir }}
+
+  publish:
+    name: Publish Base Tools
+    needs: build
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Download Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/artifacts
+
+      - name: Stage Files
+        run: mkdir ${{ runner.temp }}/basetools ;
+          mv ${{ runner.temp }}/artifacts/basetools-GCC5-X64       ${{ runner.temp }}/basetools/Linux-x86 ;
+          chmod a+x ${{ runner.temp }}/basetools/Linux-x86/* ;
+          mv ${{ runner.temp }}/artifacts/basetools-GCC5-AARCH64   ${{ runner.temp }}/basetools/Linux-ARM-64 ;
+          chmod a+x ${{ runner.temp }}/basetools/Linux-ARM-64/* ;
+          mv ${{ runner.temp }}/artifacts/basetools-VS2022-IA32    ${{ runner.temp }}/basetools/Windows-x86 ;
+          mv ${{ runner.temp }}/artifacts/basetools-VS2022-AARCH64 ${{ runner.temp }}/basetools/Windows-ARM-64 ;
+
+      - name: Package Files
+        run: |
+          cd ${{ runner.temp }} ;
+          zip -r basetools-${{ github.event.release.tag_name }}.zip basetools/* ;
+          tar -czf basetools-${{ github.event.release.tag_name }}.tar.gz basetools/*
+
+      - name: Upload Release Asset
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload ${{ github.event.release.tag_name }} ${{ runner.temp }}/basetools-*.zip
+          gh release upload ${{ github.event.release.tag_name }} ${{ runner.temp }}/basetools-*.tar.gz

--- a/FfaFeaturePkg/Library/TestServiceLibRust/src/test_svc.rs
+++ b/FfaFeaturePkg/Library/TestServiceLibRust/src/test_svc.rs
@@ -5,13 +5,9 @@ use odp_ffa::{Function, NotificationSet};
 use uuid::{uuid, Uuid};
 
 // Protocol CMD definitions for Test
+#[allow(dead_code)]
 const TEST_OPCODE_BASE: u64 = 0xDEF0;
 const TEST_OPCODE_TEST_NOTIFICATION: u64 = 0xDEF1;
-
-// Protocol status code definitions for Test
-const TEST_STATUS_SUCCESS: i64 = 0;
-const TEST_STATUS_GENERIC_ERROR: i64 = -1;
-const TEST_STATUS_INVALID_PARAMETER: i64 = -2;
 
 /* Test Service Defines */
 const DELAYED_SRI_BIT_POS: u64 = 1;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,6 @@
 [toolchain]
-channel = "1.85.0"
+channel = "1.89.0"
 
 [tool]
-cargo-make = "0.37.9"
-cargo-tarpaulin = "0.27.3"
+cargo-make = "0.37.24"
+cargo-tarpaulin = "0.31.5"


### PR DESCRIPTION
## Description

This change brings the pipeline building of rust secure partitions to be tied to releases of this repo.

Instead of relying on the secure partitions to be built as part of the build process of platform, this change took the approach of releasing binary files to be consumed by platforms.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

This was tested on pipeline build and ensure the binaries are properly generated.

## Integration Instructions

One should ingest the artifacts associated with a particular release if the secure partition is to be integrated in the platform level.
