### PR TITLE
Fix a path issue in the git artifact upload step

### DIFF
--- a/.github/workflows/release-secure-partitions.yml
+++ b/.github/workflows/release-secure-partitions.yml
@@ -79,5 +79,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release upload ${{ github.event.release.tag_name }} ${{ runner.temp }}/rust-secure-partitions-*.zip
-          gh release upload ${{ github.event.release.tag_name }} ${{ runner.temp }}/rust-secure-partitions-*.tar.gz
+          gh release upload ${{ github.event.release.tag_name }} ${{ runner.temp }}/artifacts/rust-secure-partitions-*.zip
+          gh release upload ${{ github.event.release.tag_name }} ${{ runner.temp }}/artifacts/rust-secure-partitions-*.tar.gz


### PR DESCRIPTION
## Description

The previous fix missed a step to update the path where the zipped artifacts should be uploaded.

This change is created to fix this issue.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

The change matches the previous step that creates the binaries.

## Integration Instructions

N/A
