### PR TITLE
Add permission access to fix the release attachment step

### DIFF
--- a/.github/workflows/release-secure-partitions.yml
+++ b/.github/workflows/release-secure-partitions.yml
@@ -27,6 +27,9 @@ jobs:
     name: Build Rust Secure Partition
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: write
+
     steps:
       - name: Checkout Code
         uses: actions/checkout@v5


### PR DESCRIPTION
## Description

This change adds the permission configuration for the release binary attachment step.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Pipeline change only.

## Integration Instructions

N/A
