### PR TITLE
RUST SP Updates + Cargo.toml Update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,10 @@ aarch64-rt = { version = "0.2.2", default-features = false, features = [
     "el1",
     "exceptions",
 ] }
-aarch64-haf = { git = "https://github.com/OpenDevicePartnership/odp-secure-services", rev = "79e24eca" }
-ec-service-lib = { git = "https://github.com/OpenDevicePartnership/odp-secure-services", rev = "79e24eca" }
-odp-ffa = { git = "https://github.com/OpenDevicePartnership/odp-secure-services", rev = "79e24eca" }
-hafnium = { git = "https://github.com/OpenDevicePartnership/odp-secure-services", rev = "79e24eca" }
+aarch64-haf = { git = "https://github.com/OpenDevicePartnership/odp-secure-services", rev = "54439c76" }
+ec-service-lib = { git = "https://github.com/OpenDevicePartnership/odp-secure-services", rev = "54439c76" }
+odp-ffa = { git = "https://github.com/OpenDevicePartnership/odp-secure-services", rev = "54439c76" }
+hafnium = { git = "https://github.com/OpenDevicePartnership/odp-secure-services", rev = "54439c76" }
 log = { version = "0.4", default-features = false }
 uuid = { version = "1.0", default-features = false, features = ["v1"] }
 test-service-lib = { path = "FfaFeaturePkg/Library/TestServiceLibRust" }

--- a/FfaFeaturePkg/SecurePartitions/MsSecurePartitionRust/src/main.rs
+++ b/FfaFeaturePkg/SecurePartitions/MsSecurePartitionRust/src/main.rs
@@ -29,13 +29,19 @@ fn main() -> ! {
     log::info!("FFA version: {}.{}", version.major(), version.minor());
 
     #[cfg(feature = "tpm")]
+    // Non-secure CRB region shared between non-secure world and secure world.
+    let tpm_internal_crb_address: u64 = 0x10000200000;
+    // Secure CRB region only accessible by the TPM service.
+    let tpm_external_crb_address: u64 = 0x60120000;
+    log::info!("TPM Internal CRB Address: {:X}", tpm_internal_crb_address);
+    log::info!("TPM External CRB Address: {:X}", tpm_external_crb_address);
     let tpm_service = {
         // Initialize the TPM service with its state-translation backend.
         let mut svc = TpmService::new(TpmSst::new());
 
         // SAFETY: Writes to the memory-mapped internal CRB regions and initializes
         //         the SST layer for the external TPM device.
-        unsafe { svc.init(0x10000200000) };
+        unsafe { svc.init(tpm_internal_crb_address, tpm_external_crb_address) };
         svc
     };
     #[cfg(not(feature = "tpm"))]

--- a/FfaFeaturePkg/SecurePartitions/MsSecurePartitionRust/src/main.rs
+++ b/FfaFeaturePkg/SecurePartitions/MsSecurePartitionRust/src/main.rs
@@ -29,13 +29,13 @@ fn main() -> ! {
     log::info!("FFA version: {}.{}", version.major(), version.minor());
 
     #[cfg(feature = "tpm")]
-    // Non-secure CRB region shared between non-secure world and secure world.
-    let tpm_internal_crb_address: u64 = 0x10000200000;
-    // Secure CRB region only accessible by the TPM service.
-    let tpm_external_crb_address: u64 = 0x60120000;
-    log::info!("TPM Internal CRB Address: {:X}", tpm_internal_crb_address);
-    log::info!("TPM External CRB Address: {:X}", tpm_external_crb_address);
     let tpm_service = {
+        // Non-secure CRB region shared between non-secure world and secure world.
+        let tpm_internal_crb_address: u64 = 0x10000200000;
+        // Secure CRB region only accessible by the TPM service.
+        let tpm_external_crb_address: u64 = 0x60120000;
+        log::info!("TPM Internal CRB Address: {:X}", tpm_internal_crb_address);
+        log::info!("TPM External CRB Address: {:X}", tpm_external_crb_address);
         // Initialize the TPM service with its state-translation backend.
         let mut svc = TpmService::new(TpmSst::new());
 
@@ -44,6 +44,7 @@ fn main() -> ! {
         unsafe { svc.init(tpm_internal_crb_address, tpm_external_crb_address) };
         svc
     };
+
     #[cfg(not(feature = "tpm"))]
     let tpm_service = TpmServiceStub::new();
 


### PR DESCRIPTION
## Description

Updating the Cargo.toml to point to the latest odp-secure-services release commit. This includes an update to the TPM service to allow the SP to pass in both the internal and external CRB addresses. It also includes an update to reduce the verbosity of the logging by changing the logs from info to trace. Updated the RUST SP to pass in both of the CRB addresses to the TPM service init function.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Built QEMU SBSA with TPM enabled. Verified TPM functionality with reduced log verbosity.

## Integration Instructions

N/A
