### PR TITLE
Produce TPM enabled binaries along side non-TPM binaries

### DIFF
--- a/.github/workflows/release-secure-partitions.yml
+++ b/.github/workflows/release-secure-partitions.yml
@@ -44,9 +44,17 @@ jobs:
       - name: Build Secure Partitions
         run: |
           mkdir -p ${{ env.OUTOUTPUT_DIR }}
+
+          # TPM-disabled (default features) build
           cargo build --target=${{ env.BUILD_TARGET }}
           cargo objcopy --target=${{ env.BUILD_TARGET }} -- -O binary ${{ env.OUTOUTPUT_DIR }}/msft-sp.bin
           cp target/${{ env.BUILD_TARGET }}/debug/msft-sp ${{ env.OUTOUTPUT_DIR }}/msft-sp.elf
+
+          # TPM-enabled build
+          cargo build --target=${{ env.BUILD_TARGET }} --features tpm
+          cargo objcopy --target=${{ env.BUILD_TARGET }} --features tpm -- -O binary ${{ env.OUTOUTPUT_DIR }}/msft-sp-tpm.bin
+          cp target/${{ env.BUILD_TARGET }}/debug/msft-sp ${{ env.OUTOUTPUT_DIR }}/msft-sp-tpm.elf
+
           cp Cargo.lock ${{ env.OUTOUTPUT_DIR }}/Cargo.lock
 
       - name: Package Files


### PR DESCRIPTION
## Description

This change updates the pipeline to produce 2 binaries during release process, so that developers do not have to build TPM enabled binaries locally.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

This was tested locally and confirmed the msft-sp-tpm.bin has TPM functionality enabled.

## Integration Instructions

If TPM features is enabled on the platform side, use the `msft-sp-tpm.bin`.
