### PR TITLE
ODP Updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,10 @@ aarch64-rt = { version = "0.2.2", default-features = false, features = [
     "el1",
     "exceptions",
 ] }
-aarch64-haf = { git = "https://github.com/OpenDevicePartnership/odp-secure-services", rev = "54439c76" }
-ec-service-lib = { git = "https://github.com/OpenDevicePartnership/odp-secure-services", rev = "54439c76" }
-odp-ffa = { git = "https://github.com/OpenDevicePartnership/odp-secure-services", rev = "54439c76" }
-hafnium = { git = "https://github.com/OpenDevicePartnership/odp-secure-services", rev = "54439c76" }
+aarch64-haf = { git = "https://github.com/OpenDevicePartnership/odp-secure-services", rev = "6776d952" }
+ec-service-lib = { git = "https://github.com/OpenDevicePartnership/odp-secure-services", rev = "6776d952" }
+odp-ffa = { git = "https://github.com/OpenDevicePartnership/odp-secure-services", rev = "6776d952" }
+hafnium = { git = "https://github.com/OpenDevicePartnership/odp-secure-services", rev = "6776d952" }
 log = { version = "0.4", default-features = false }
 uuid = { version = "1.0", default-features = false, features = ["v1"] }
 test-service-lib = { path = "FfaFeaturePkg/Library/TestServiceLibRust" }


### PR DESCRIPTION
## Description

Updated the ODP crates to the latest revision to include defaulting locality0 and locality1 to OPEN.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Built both Q35 and Virt with TPM enabled. Verified TPM functionality without the patch to open localities.

## Integration Instructions

N/A
